### PR TITLE
skip empty frames

### DIFF
--- a/ac-ffmpeg/src/codec/audio/mod.rs
+++ b/ac-ffmpeg/src/codec/audio/mod.rs
@@ -512,6 +512,10 @@ impl Encoder for AudioEncoder {
     }
 
     fn try_push(&mut self, frame: AudioFrame) -> Result<(), CodecError> {
+        if frame.samples() == 0 {
+            return Ok(())
+        }
+
         let frame = frame.with_time_base(self.time_base);
 
         unsafe {


### PR DESCRIPTION
work around observed segfault on ffmpeg 5.1 on x86 (does not repro on aarch64)